### PR TITLE
[TC-915] Pass onClick function to placement engine subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Pass `onClick` function to placement engine subscribers
+
 ## 2.1.2 (2019-04-29)
 
 * Refactor reducer to accept a context argument

--- a/package-lock.json
+++ b/package-lock.json
@@ -2917,9 +2917,9 @@
       }
     },
     "fkit": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fkit/-/fkit-3.2.0.tgz",
-      "integrity": "sha512-dnvlbGUpHW0LAlKOKH8UetKBDO2E3VICUqh8HiJC06rxLXsNZQrXKg6Kg6zvoQIAjpCcW3c8IwMK9E/ZgY/bdg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fkit/-/fkit-3.3.0.tgz",
+      "integrity": "sha512-z14teiQRv/bh0HMTiNaTTO7oHnV03r0gEiv3f01l0Gn/Cz9WqRk+rWOWP7Br/Zw4NfcxeWG8CpDRMdtjRrAIsw=="
     },
     "flat-cache": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "bulb": "^6.1.0",
-    "fkit": "^3.2.0",
+    "fkit": "^3.3.0",
     "ua-parser-js": "^0.7.19"
   },
   "devDependencies": {

--- a/src/placePromos.test.js
+++ b/src/placePromos.test.js
@@ -13,7 +13,7 @@ describe('placePromos', () => {
   const e = { promoId: 5, groupId: 2, constraints: 'user.url = "foo"' }
   const f = { promoId: 6, groupId: 2, constraints: 'user.url = "bar"' }
   const g = { promoId: 8, groupId: 3, constraints: 'browser.name = "Chrome"' }
-  const h = { promoId: 7, groupId: 3, constraints: 'promoId IN user.blocked' }
+  const h = { promoId: 7, groupId: 3, constraints: 'promoId IN user.blocked.promos' }
   const promos = [a, b, c, d, e, f, g, h]
 
   it('ensures only one promo from each group is placed', () => {
@@ -31,6 +31,6 @@ describe('placePromos', () => {
   })
 
   it('allows filtering promos by promoId', () => {
-    expect(placePromos(promos, { blocked: [7] })).toEqual([a, b, c, h])
+    expect(placePromos(promos, { blocked: { promos: [7] } })).toEqual([a, b, c, h])
   })
 })

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -17,6 +17,9 @@ export default function placementEngine (promos, window) {
   // Create the bus signal.
   const bus = new Bus()
 
+  // A function that emits a `click` event on the bus.
+  const onClick = promo => bus.next({ type: 'click', promo })
+
   // A function that emits a `close` event on the bus.
   const onClose = promo => bus.next({ type: 'close', promo })
 
@@ -31,13 +34,13 @@ export default function placementEngine (promos, window) {
     .startWith({ type: 'visit' })
 
     // Scan the reducer function over the events emitted on the bus.
-    .scan(reducer({ window, promos }), initialState)
+    .scan((state, event) => reducer(promos, window, state, event), initialState)
 
     // Store the user state as a side effect.
     .tap(({ user }) => set(window.localStorage, user))
 
     // Emit the placed promos and callback functions.
-    .map(({ promos }) => ({ promos, onClose }))
+    .map(({ promos }) => ({ promos, onClick, onClose }))
 
   return stateSignal
 }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -44,6 +44,19 @@ function trackImpressions (promos, ts, user) {
 }
 
 /**
+ * Tracks the engagements for the given promo.
+ *
+ * @private
+ */
+function trackEngagements (promo, ts, user) {
+  return compose(
+    updateEntity(['engagements', 'campaigns', promo.campaignId], ts),
+    updateEntity(['engagements', 'groups', promo.groupId], ts),
+    updateEntity(['engagements', 'promos', promo.promoId], ts)
+  )(user)
+}
+
+/**
  * Increments the counter and sets the timestamp for the given entity.
  *
  * @private
@@ -78,6 +91,9 @@ function reducer (context, state, event) {
   if (event.type === 'visit') {
     // Increment the number of user visits.
     user = incrementVisits(user)
+  } else if (event.type === 'click') {
+    // Add promo to the list of engagements.
+    user = trackEngagements(event.promo, ts, user)
   } else if (event.type === 'close') {
     // Add promo to the list of blocked promos.
     user = blockPromo(event.promo, ts, user)

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,5 +1,4 @@
 import compose from 'fkit/dist/compose'
-import curry from 'fkit/dist/curry'
 import id from 'fkit/dist/id'
 import inc from 'fkit/dist/inc'
 import last from 'fkit/dist/last'
@@ -78,14 +77,14 @@ function updateEntity (keyPath, ts) {
 /**
  * Applies an event to the current state to yield a new state.
  *
- * @param {Object} context The context object.
+ * @param {Array} promos The list of promos.
+ * @param {Window} window The window object.
  * @param {Object} state The current state.
  * @param {Object} event The event.
  * @returns A new state.
  */
-function reducer (context, state, event) {
+function reducer (promos, window, state, event) {
   const ts = timestamp()
-  let { window, promos } = context
   let { user } = state
 
   if (event.type === 'visit') {
@@ -108,4 +107,4 @@ function reducer (context, state, event) {
   return { promos: placedPromos, user }
 }
 
-export default curry(reducer)
+export default reducer

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -17,7 +17,6 @@ describe('reducer', () => {
     { promoId: 2, groupId: 1, campaignId: 1 },
     { promoId: 3, campaignId: 1 }
   ]
-  const context = { window, promos }
 
   beforeEach(() => {
     state = {
@@ -37,13 +36,13 @@ describe('reducer', () => {
 
     it('updates the promos', () => {
       expect(state).toHaveProperty('promos', [])
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('promos', promos)
     })
 
     it('updates the campaign impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.campaigns')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.impressions.campaigns', {
         1: { count: 3, timestamp: '123' }
       })
@@ -51,7 +50,7 @@ describe('reducer', () => {
 
     it('updates the group impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.groups')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.impressions.groups', {
         1: { count: 2, timestamp: '123' }
       })
@@ -59,7 +58,7 @@ describe('reducer', () => {
 
     it('updates the promo impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.promos')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.impressions.promos', {
         1: { count: 1, timestamp: '123' },
         2: { count: 1, timestamp: '123' },
@@ -73,7 +72,7 @@ describe('reducer', () => {
 
     it('increments the number of visits', () => {
       expect(state).toHaveProperty('user.visits', 1)
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.visits', 2)
     })
   })
@@ -86,7 +85,7 @@ describe('reducer', () => {
 
     it('updates the campaign engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.campaigns')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.engagements.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
@@ -94,7 +93,7 @@ describe('reducer', () => {
 
     it('updates the group engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.groups')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.engagements.groups', {
         1: { count: 1, timestamp: '123' }
       })
@@ -102,7 +101,7 @@ describe('reducer', () => {
 
     it('updates the promo engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.promos')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.engagements.promos', {
         1: { count: 1, timestamp: '123' }
       })
@@ -117,7 +116,7 @@ describe('reducer', () => {
 
     it('updates the blocked campaigns', () => {
       expect(state).not.toHaveProperty('user.blocked.campaigns')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.blocked.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
@@ -125,7 +124,7 @@ describe('reducer', () => {
 
     it('updates the blocked groups', () => {
       expect(state).not.toHaveProperty('user.blocked.groups')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.blocked.groups', {
         1: { count: 1, timestamp: '123' }
       })
@@ -133,7 +132,7 @@ describe('reducer', () => {
 
     it('updates the blocked promos', () => {
       expect(state).not.toHaveProperty('user.blocked.promos')
-      state = reducer(context, state, event)
+      state = reducer(promos, window, state, event)
       expect(state).toHaveProperty('user.blocked.promos', {
         1: { count: 1, timestamp: '123' }
       })

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -61,27 +61,55 @@ describe('reducer', () => {
     })
   })
 
+  describe('with a click event', () => {
+    const event = {
+      type: 'click',
+      promo: { promoId: 1, groupId: 1, campaignId: 1 }
+    }
+
+    it('updates the campaign engagements', () => {
+      const result = reducer(context, state, event)
+      expect(result).toHaveProperty('user.engagements.campaigns', {
+        1: { count: 1, timestamp: '123' }
+      })
+    })
+
+    it('updates the group engagements', () => {
+      const result = reducer(context, state, event)
+      expect(result).toHaveProperty('user.engagements.groups', {
+        1: { count: 1, timestamp: '123' }
+      })
+    })
+
+    it('updates the promo engagements', () => {
+      const result = reducer(context, state, event)
+      expect(result).toHaveProperty('user.engagements.promos', {
+        1: { count: 1, timestamp: '123' }
+      })
+    })
+  })
+
   describe('with a close event', () => {
     const event = {
       type: 'close',
       promo: { promoId: 1, groupId: 1, campaignId: 1 }
     }
 
-    it('adds the campaign to the list of blocked promos', () => {
+    it('updates the blocked campaigns', () => {
       const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
-    it('adds the group to the list of blocked promos', () => {
+    it('updates the blocked groups', () => {
       const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.groups', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
-    it('adds the promo to the list of blocked promos', () => {
+    it('updates the blocked promos', () => {
       const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.promos', {
         1: { count: 1, timestamp: '123' }

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -9,6 +9,8 @@ jest.mock('./utils', () => ({
   timestamp: jest.fn(() => '123')
 }))
 
+let state
+
 describe('reducer', () => {
   const promos = [
     { promoId: 1, groupId: 1, campaignId: 1 },
@@ -16,36 +18,49 @@ describe('reducer', () => {
     { promoId: 3, campaignId: 1 }
   ]
   const context = { window, promos }
-  const state = {
-    promos: [],
-    user: {
-      blocked: {},
-      impressions: {},
-      visits: 1
-    },
-    window: {}
-  }
+
+  beforeEach(() => {
+    state = {
+      promos: [],
+      user: {
+        blocked: {},
+        impressions: {},
+        engagements: {},
+        visits: 1
+      },
+      window: {}
+    }
+  })
 
   describe('with any event', () => {
     const event = {}
 
+    it('updates the promos', () => {
+      expect(state).toHaveProperty('promos', [])
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('promos', promos)
+    })
+
     it('updates the campaign impressions', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.impressions.campaigns', {
+      expect(state).not.toHaveProperty('user.impressions.campaigns')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.impressions.campaigns', {
         1: { count: 3, timestamp: '123' }
       })
     })
 
     it('updates the group impressions', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.impressions.groups', {
+      expect(state).not.toHaveProperty('user.impressions.groups')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.impressions.groups', {
         1: { count: 2, timestamp: '123' }
       })
     })
 
     it('updates the promo impressions', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.impressions.promos', {
+      expect(state).not.toHaveProperty('user.impressions.promos')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.impressions.promos', {
         1: { count: 1, timestamp: '123' },
         2: { count: 1, timestamp: '123' },
         3: { count: 1, timestamp: '123' }
@@ -54,10 +69,12 @@ describe('reducer', () => {
   })
 
   describe('with a visit event', () => {
+    const event = { type: 'visit' }
+
     it('increments the number of visits', () => {
-      const event = { type: 'visit' }
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.visits', 2)
+      expect(state).toHaveProperty('user.visits', 1)
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.visits', 2)
     })
   })
 
@@ -68,22 +85,25 @@ describe('reducer', () => {
     }
 
     it('updates the campaign engagements', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.engagements.campaigns', {
+      expect(state).not.toHaveProperty('user.engagements.campaigns')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.engagements.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('updates the group engagements', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.engagements.groups', {
+      expect(state).not.toHaveProperty('user.engagements.groups')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.engagements.groups', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('updates the promo engagements', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.engagements.promos', {
+      expect(state).not.toHaveProperty('user.engagements.promos')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.engagements.promos', {
         1: { count: 1, timestamp: '123' }
       })
     })
@@ -96,22 +116,25 @@ describe('reducer', () => {
     }
 
     it('updates the blocked campaigns', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.blocked.campaigns', {
+      expect(state).not.toHaveProperty('user.blocked.campaigns')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.blocked.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('updates the blocked groups', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.blocked.groups', {
+      expect(state).not.toHaveProperty('user.blocked.groups')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.blocked.groups', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('updates the blocked promos', () => {
-      const result = reducer(context, state, event)
-      expect(result).toHaveProperty('user.blocked.promos', {
+      expect(state).not.toHaveProperty('user.blocked.promos')
+      state = reducer(context, state, event)
+      expect(state).toHaveProperty('user.blocked.promos', {
         1: { count: 1, timestamp: '123' }
       })
     })


### PR DESCRIPTION
When the promos engine receives a `click` event for a promo, it will add that promo to the list of engagements.

```json
{
  "engagements":{
    "promos":{
      "2":{"count":10,"timestamp":"2019-04-26T04:08:38.093Z"},
      "3":{"count":4,"timestamp":"2019-04-26T04:09:13.619Z"}
    },
    "groups":{
      "2":{"count":14,"timestamp":"2019-04-26T04:09:13.619Z"}
    },
    "campaigns":{
      "1":{"count":14,"timestamp":"2019-04-26T04:09:13.619Z"}
    }
  }
}
```

This means we can write constraints to ensure that the donation popups won't be shown if a user has already clicked on one of the donations promos

For example, if we want to ensure that a promo isn't shown if someone has already clicked one of the promos in the group:

```sql
groupId NOT IN user.engagements.groups
```

Or perhaps we don't want to show a promo if _any_ of the promos in the donations campaign have been clicked:

```sql
campaignId NOT IN user.engagements.campaigns
```

It's up to us 😄 

## How to Test

There is no easy way to test this integrates with TC properly, other than npm-linking the package into TC and making some code changes in TC.

Hopefully from the tests you can see the expected behaviour of the API changes is verified.