### PR TITLE
[TC-916] Fix issue with placementEngine initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix an issue where the placementEngine was initially emitting _all_ promos to subscribers, before filtering them
+
 ## 2.1.0 (2019-04-17)
 
 * Add `NOT LIKE` operator

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -22,7 +22,7 @@ export default function placementEngine (promos, window) {
 
   // Create the initial state object. Every time an event is emitted on the
   // bus, a new state will be generated.
-  const initialState = { promos, user, window }
+  const initialState = { promos: [], user, window }
 
   // The state signal emits the current placement engine state whenever an
   // event is emitted on the bus.

--- a/src/placementEngine.test.js
+++ b/src/placementEngine.test.js
@@ -9,8 +9,9 @@ jest.mock('./userState', () => ({
 jest.mock('./reducer', () => jest.fn(a => a))
 
 describe('placePromos', () => {
-  it('calls the callback', done => {
-    placementEngine([], window)
+  it('initially calls the callback with an empty array', done => {
+    const promos = [{ promoid: 1 }]
+    placementEngine(promos, window)
       .subscribe(({ promos }) => {
         expect(promos).toEqual([])
         done()


### PR DESCRIPTION
Fix an issue where the placementEngine was initially emitting all promos to subscribers, before filtering them.