### PR TITLE
Refactor the reducer to accept a context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Refactor reducer to accept a context argument
+
 ## 2.1.1 (2019-04-29)
 
 * Fix an issue where the placementEngine was initially emitting _all_ promos to subscribers, before filtering them

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -22,7 +22,7 @@ export default function placementEngine (promos, window) {
 
   // Create the initial state object. Every time an event is emitted on the
   // bus, a new state will be generated.
-  const initialState = { promos: [], user, window }
+  const initialState = { promos: [], user }
 
   // The state signal emits the current placement engine state whenever an
   // event is emitted on the bus.
@@ -31,12 +31,12 @@ export default function placementEngine (promos, window) {
     .startWith({ type: 'visit' })
 
     // Scan the reducer function over the events emitted on the bus.
-    .scan(reducer, initialState)
+    .scan(reducer({ window, promos }), initialState)
 
     // Store the user state as a side effect.
-    .tap(({ user, window }) => set(window.localStorage, user))
+    .tap(({ user }) => set(window.localStorage, user))
 
-    // Emit the placed promos and onClose callback.
+    // Emit the placed promos and callback functions.
     .map(({ promos }) => ({ promos, onClose }))
 
   return stateSignal

--- a/src/placementEngine.test.js
+++ b/src/placementEngine.test.js
@@ -6,7 +6,7 @@ jest.mock('./userState', () => ({
   set: jest.fn()
 }))
 
-jest.mock('./reducer', () => jest.fn(a => a))
+jest.mock('./reducer', () => jest.fn(context => state => state))
 
 describe('placePromos', () => {
   it('initially calls the callback with an empty array', done => {

--- a/src/reducer.test.js
+++ b/src/reducer.test.js
@@ -10,12 +10,14 @@ jest.mock('./utils', () => ({
 }))
 
 describe('reducer', () => {
+  const promos = [
+    { promoId: 1, groupId: 1, campaignId: 1 },
+    { promoId: 2, groupId: 1, campaignId: 1 },
+    { promoId: 3, campaignId: 1 }
+  ]
+  const context = { window, promos }
   const state = {
-    promos: [
-      { promoId: 1, groupId: 1, campaignId: 1 },
-      { promoId: 2, groupId: 1, campaignId: 1 },
-      { promoId: 3, campaignId: 1 }
-    ],
+    promos: [],
     user: {
       blocked: {},
       impressions: {},
@@ -28,21 +30,21 @@ describe('reducer', () => {
     const event = {}
 
     it('updates the campaign impressions', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.impressions.campaigns', {
         1: { count: 3, timestamp: '123' }
       })
     })
 
     it('updates the group impressions', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.impressions.groups', {
         1: { count: 2, timestamp: '123' }
       })
     })
 
     it('updates the promo impressions', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.impressions.promos', {
         1: { count: 1, timestamp: '123' },
         2: { count: 1, timestamp: '123' },
@@ -54,7 +56,7 @@ describe('reducer', () => {
   describe('with a visit event', () => {
     it('increments the number of visits', () => {
       const event = { type: 'visit' }
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.visits', 2)
     })
   })
@@ -66,21 +68,21 @@ describe('reducer', () => {
     }
 
     it('adds the campaign to the list of blocked promos', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('adds the group to the list of blocked promos', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.groups', {
         1: { count: 1, timestamp: '123' }
       })
     })
 
     it('adds the promo to the list of blocked promos', () => {
-      const result = reducer(state, event)
+      const result = reducer(context, state, event)
       expect(result).toHaveProperty('user.blocked.promos', {
         1: { count: 1, timestamp: '123' }
       })


### PR DESCRIPTION
The context contains the list of _all_ candidate promos for the placement engine to filter. It also contains a reference to the window object.