### PR TITLE
[TC-937] Fix issue with placement engine events

### DIFF
--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -1,7 +1,7 @@
 import Bus from 'bulb/dist/Bus'
 
-import reducer from './reducer'
-import { get, set } from './userState'
+import stateMachine from './stateMachine'
+import { get } from './userState'
 
 /**
  * The placement engine is responsible for placing the given promos into slots.
@@ -23,9 +23,8 @@ export default function placementEngine (promos, window) {
   // A function that emits a `close` event on the bus.
   const onClose = promo => bus.next({ type: 'close', promo })
 
-  // Create the initial state object. Every time an event is emitted on the
-  // bus, a new state will be generated.
-  const initialState = { promos: [], user }
+  // Create the initial state object.
+  const initialState = { user }
 
   // The state signal emits the current placement engine state whenever an
   // event is emitted on the bus.
@@ -33,11 +32,8 @@ export default function placementEngine (promos, window) {
     // Emit an initial `visit` event on the bus.
     .startWith({ type: 'visit' })
 
-    // Scan the reducer function over the events emitted on the bus.
-    .scan((state, event) => reducer(promos, window, state, event), initialState)
-
-    // Store the user state as a side effect.
-    .tap(({ user }) => set(window.localStorage, user))
+    // Run the state machine function over the events emitted on the bus.
+    .stateMachine(stateMachine(promos, window), initialState)
 
     // Emit the placed promos and callback functions.
     .map(({ promos }) => ({ promos, onClick, onClose }))

--- a/src/stateMachine.test.js
+++ b/src/stateMachine.test.js
@@ -1,48 +1,62 @@
-import reducer from './reducer'
+import stateMachine from './stateMachine'
+import { set } from './userState'
 
 // Mock the placePromos function to return the promos unchanged.
-jest.mock('./placePromos', () =>
-  jest.fn(promos => promos)
-)
+jest.mock('./placePromos', () => jest.fn(promos => promos))
 
-jest.mock('./utils', () => ({
-  timestamp: jest.fn(() => '123')
-}))
+// Mock the user state setter.
+jest.mock('./userState', () => ({ set: jest.fn() }))
+
+// Mock the timestamp function.
+jest.mock('./utils', () => ({ timestamp: jest.fn(() => '123') }))
 
 let state
 
-describe('reducer', () => {
+describe('stateMachine', () => {
   const promos = [
     { promoId: 1, groupId: 1, campaignId: 1 },
     { promoId: 2, groupId: 1, campaignId: 1 },
     { promoId: 3, campaignId: 1 }
   ]
+  const emit = { next: jest.fn() }
 
   beforeEach(() => {
     state = {
-      promos: [],
       user: {
         blocked: {},
         impressions: {},
         engagements: {},
         visits: 1
-      },
-      window: {}
+      }
     }
   })
 
   describe('with any event', () => {
     const event = {}
 
-    it('updates the promos', () => {
-      expect(state).toHaveProperty('promos', [])
-      state = reducer(promos, window, state, event)
-      expect(state).toHaveProperty('promos', promos)
+    it('loads and stores the user state', () => {
+      stateMachine(promos, window)(state, event, emit)
+      expect(set).toHaveBeenLastCalledWith(window.localStorage, state.user)
+    })
+  })
+
+  describe('with a visit event', () => {
+    const event = { type: 'visit' }
+
+    it('emits the placed promos', () => {
+      stateMachine(promos, window)(state, event, emit)
+      expect(emit.next).toHaveBeenLastCalledWith({ promos })
+    })
+
+    it('increments the number of visits', () => {
+      expect(state).toHaveProperty('user.visits', 1)
+      state = stateMachine(promos, window)(state, event, emit)
+      expect(state).toHaveProperty('user.visits', 2)
     })
 
     it('updates the campaign impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.campaigns')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.impressions.campaigns', {
         1: { count: 3, timestamp: '123' }
       })
@@ -50,7 +64,7 @@ describe('reducer', () => {
 
     it('updates the group impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.groups')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.impressions.groups', {
         1: { count: 2, timestamp: '123' }
       })
@@ -58,22 +72,12 @@ describe('reducer', () => {
 
     it('updates the promo impressions', () => {
       expect(state).not.toHaveProperty('user.impressions.promos')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.impressions.promos', {
         1: { count: 1, timestamp: '123' },
         2: { count: 1, timestamp: '123' },
         3: { count: 1, timestamp: '123' }
       })
-    })
-  })
-
-  describe('with a visit event', () => {
-    const event = { type: 'visit' }
-
-    it('increments the number of visits', () => {
-      expect(state).toHaveProperty('user.visits', 1)
-      state = reducer(promos, window, state, event)
-      expect(state).toHaveProperty('user.visits', 2)
     })
   })
 
@@ -85,7 +89,7 @@ describe('reducer', () => {
 
     it('updates the campaign engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.campaigns')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.engagements.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
@@ -93,7 +97,7 @@ describe('reducer', () => {
 
     it('updates the group engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.groups')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.engagements.groups', {
         1: { count: 1, timestamp: '123' }
       })
@@ -101,7 +105,7 @@ describe('reducer', () => {
 
     it('updates the promo engagements', () => {
       expect(state).not.toHaveProperty('user.engagements.promos')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.engagements.promos', {
         1: { count: 1, timestamp: '123' }
       })
@@ -116,7 +120,7 @@ describe('reducer', () => {
 
     it('updates the blocked campaigns', () => {
       expect(state).not.toHaveProperty('user.blocked.campaigns')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.blocked.campaigns', {
         1: { count: 1, timestamp: '123' }
       })
@@ -124,7 +128,7 @@ describe('reducer', () => {
 
     it('updates the blocked groups', () => {
       expect(state).not.toHaveProperty('user.blocked.groups')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.blocked.groups', {
         1: { count: 1, timestamp: '123' }
       })
@@ -132,7 +136,7 @@ describe('reducer', () => {
 
     it('updates the blocked promos', () => {
       expect(state).not.toHaveProperty('user.blocked.promos')
-      state = reducer(promos, window, state, event)
+      state = stateMachine(promos, window)(state, event, emit)
       expect(state).toHaveProperty('user.blocked.promos', {
         1: { count: 1, timestamp: '123' }
       })


### PR DESCRIPTION
There was an issue with using a reducer function which caused the placement engine to emit the placed promos _every_ time an event was triggered. By using a state machine, we can have fine-grained control over when events are emitted.

How to Test

- Ensure that `promos-client` and TC are using the same node version
- Build the package: `make dist`
- In the promos client directory: `npm ln`
- In the TC directory: `npm ln @theconversation/promos-client`
- Fire up TC and check that promos work as expected. Note: because the promos are no longer reemitted for every event (i.e. when you dismiss a popup), reactively closing the popup no longer works. To fix this it will require a change in TC.