### PR TITLE
Include horizontal and vertical scroll percentages in the context

### DIFF
--- a/src/createContext.js
+++ b/src/createContext.js
@@ -2,7 +2,7 @@ import UAParser from 'ua-parser-js'
 import toLower from 'fkit/dist/toLower'
 import toUpper from 'fkit/dist/toUpper'
 
-import { age } from './utils'
+import { age, scrollPercentX, scrollPercentY } from './utils'
 
 /**
  * Creates a new placement context that contains objects and functions to be
@@ -13,16 +13,21 @@ import { age } from './utils'
  */
 export default function createContext (user) {
   const uaParser = new UAParser(window.navigator.userAgent)
+  const scroll = {
+    percentX: scrollPercentX(),
+    percentY: scrollPercentY()
+  }
 
   return {
-    // Objects
+    // objects
     browser: uaParser.getBrowser(),
     device: uaParser.getDevice(),
     os: uaParser.getOS(),
+    scroll,
     user,
     window,
 
-    // Functions
+    // functions
     age,
     lower: toLower,
     upper: toUpper

--- a/src/createContext.test.js
+++ b/src/createContext.test.js
@@ -1,5 +1,12 @@
 import createContext from './createContext'
 
+// Mock the util functions.
+jest.mock('./utils', () => ({
+  age: jest.fn(),
+  scrollPercentX: jest.fn(() => 0.1),
+  scrollPercentY: jest.fn(() => 0.2)
+}))
+
 describe('createContext', () => {
   it('creates a placement context', () => {
     const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36'
@@ -12,6 +19,7 @@ describe('createContext', () => {
       browser: { major: '74', name: 'Chrome', version: '74.0.3729.131' },
       device: {},
       os: { name: 'Mac OS', version: '10.14.4' },
+      scroll: { percentX: 0.1, percentY: 0.2 },
       user,
       window: expect.anything(),
       age: expect.any(Function),

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,3 +98,29 @@ export const xeqBy = f => (a, b) => {
     a_ === b_
   )
 }
+
+/**
+ * Calculates the horizontal scroll amount of the page.
+ *
+ * This is more complex than it should be, because of browser inconsistencies.
+ *
+ * @return {Number} The scroll amount in percent.
+ */
+export function scrollPercentX () {
+  const a = document.documentElement
+  const b = document.body
+  return (a.scrollLeft || b.scrollLeft) / ((a.scrollWidth || b.scrollWidth) - a.clientWidth)
+}
+
+/**
+ * Calculates the vertical scroll amount of the page.
+ *
+ * This is more complex than it should be, because of browser inconsistencies.
+ *
+ * @return {Number} The scroll amount in percent.
+ */
+export function scrollPercentY () {
+  const a = document.documentElement
+  const b = document.body
+  return (a.scrollTop || b.scrollTop) / ((a.scrollHeight || b.scrollHeight) - a.clientHeight)
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,6 +1,6 @@
 import id from 'fkit/dist/id'
 
-import { age, has, like, match, timestamp, xeqBy } from './utils'
+import { age, has, like, match, scrollPercentX, scrollPercentY, timestamp, xeqBy } from './utils'
 
 describe('timestamp', () => {
   it('returns the ISO8601 timestamp', () => {
@@ -102,5 +102,25 @@ describe('xeqBy', () => {
     expect(xeqBy(id)(1, undefined)).toBe(false)
     expect(xeqBy(id)(undefined, 1)).toBe(false)
     expect(xeqBy(id)(undefined, undefined)).toBe(false)
+  })
+})
+
+describe('scrollPercentX', () => {
+  Object.defineProperty(document.documentElement, 'scrollLeft', { value: 50 })
+  Object.defineProperty(document.documentElement, 'scrollWidth', { value: 200 })
+  Object.defineProperty(document.documentElement, 'clientWidth', { value: 100 })
+
+  it('returns the horizontal scroll percentage', () => {
+    expect(scrollPercentX()).toBe(0.5)
+  })
+})
+
+describe('scrollPercentY', () => {
+  Object.defineProperty(document.documentElement, 'scrollTop', { value: 50 })
+  Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200 })
+  Object.defineProperty(document.documentElement, 'clientHeight', { value: 100 })
+
+  it('returns the vertical scroll percentage', () => {
+    expect(scrollPercentY()).toBe(0.5)
   })
 })


### PR DESCRIPTION
We want to add the ability for promos to appear when the user scrolls the page past a certain point. This PR doesn't get us all the way there, but it does lay some of the groundwork.

I added a `scroll` object to the context, which allows queries to be constrained based on the horizontal and vertical scroll offsets of the page:

```sql
scroll.percentY >= 0.75
```

Both of these values provided as a normalised percentage value (i.e. 0 <= n <= 1).

I toyed around with the idea of trying to use the [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) to do this, but I think for the first cut a simple scroll percentage will work.