### PR TITLE
Add custom state to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump lodash to 4.17.14
 * Bump standard to 13.1.0
 * Add scroll percent to context
+* Add custom state to context
 
 ## 4.0.0 (2019-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bump lodash to 4.17.14
 * Bump standard to 13.1.0
+* Add scroll percent to context
 
 ## 4.0.0 (2019-05-10)
 

--- a/src/createContext.js
+++ b/src/createContext.js
@@ -1,4 +1,5 @@
 import UAParser from 'ua-parser-js'
+import curry from 'fkit/dist/curry'
 import toLower from 'fkit/dist/toLower'
 import toUpper from 'fkit/dist/toUpper'
 
@@ -8,10 +9,11 @@ import { age, scrollPercentX, scrollPercentY } from './utils'
  * Creates a new placement context that contains objects and functions to be
  * made available to the constraint queries.
  *
- * @param {Object} user The user state.
+ * @param {Object} custom The custom state object.
+ * @param {Object} user The user state object.
  * @returns {Object} The placement context.
  */
-export default function createContext (user) {
+function createContext (custom, user) {
   const uaParser = new UAParser(window.navigator.userAgent)
   const scroll = {
     percentX: scrollPercentX(),
@@ -19,17 +21,22 @@ export default function createContext (user) {
   }
 
   return {
-    // objects
+    // browser
     browser: uaParser.getBrowser(),
     device: uaParser.getDevice(),
     os: uaParser.getOS(),
+
+    // objects
+    custom,
     scroll,
     user,
     window,
 
-    // functions
+    // utility functions
     age,
     lower: toLower,
     upper: toUpper
   }
 }
+
+export default curry(createContext)

--- a/src/createContext.test.js
+++ b/src/createContext.test.js
@@ -11,14 +11,16 @@ describe('createContext', () => {
   it('creates a placement context', () => {
     const userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36'
     const user = jest.fn()
+    const custom = { foo: 'bar' }
 
     // Stub the user agent.
     Object.defineProperty(window.navigator, 'userAgent', { value: userAgent })
 
-    expect(createContext(user)).toMatchObject({
+    expect(createContext(custom, user)).toMatchObject({
       browser: { major: '74', name: 'Chrome', version: '74.0.3729.131' },
       device: {},
       os: { name: 'Mac OS', version: '10.14.4' },
+      custom: { foo: 'bar' },
       scroll: { percentX: 0.1, percentY: 0.2 },
       user,
       window: expect.anything(),

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -25,15 +25,16 @@ const incrementVisits = update('visits', inc)
  *
  * @param {Storage} storage The storage object.
  * @param {Array} promos The list of the candidate promos.
+ * @param {Object} custom The custom state object.
  * @returns {Promise} A promise that resolves to the promos.
  */
-function placementEngine (storage, promos) {
+function placementEngine (storage, promos, custom) {
   const user = getUser(storage)
 
   // The pipeline contains the steps in the placement engine algorithm.
   const pipeline = pipe(
     updateUser(storage, incrementVisits),
-    createContext,
+    createContext(custom),
     placePromos(promos),
     resolvePromos(storage)
   )

--- a/src/placementEngine.test.js
+++ b/src/placementEngine.test.js
@@ -7,14 +7,16 @@ describe('placementEngine', () => {
   const b = { promoId: 2, constraints: 'user.visits > 1' }
   const c = { promoId: 3, constraints: 'browser.name = "Chrome"' }
   const d = { promoId: 4, groupId: 1, constraints: 'groupId NOT IN user.blocked.groups' }
-  const promos = [a, b, c, d]
+  const e = { promoId: 5, constraints: 'custom.foo = "bar"' }
+  const promos = [a, b, c, d, e]
+  const custom = { foo: 'bar' }
 
   // Stub the user agent.
   Object.defineProperty(window.navigator, 'userAgent', { value: userAgent })
 
   it('increments the number of visits', () => {
     const storage = mockStorage()
-    placementEngine(storage, promos)
+    placementEngine(storage, promos, custom)
     expect(storage.state).toMatchObject({ user: { visits: 1 } })
   })
 
@@ -25,7 +27,7 @@ describe('placementEngine', () => {
         visits: 1
       }
     })
-    const promise = placementEngine(storage, promos)
-    return expect(promise).resolves.toHaveProperty('promos', [a, b, c])
+    const promise = placementEngine(storage, promos, custom)
+    return expect(promise).resolves.toHaveProperty('promos', [a, b, c, e])
   })
 })


### PR DESCRIPTION
This PR adds a custom constraint parameter to the `placementEngine` function.

This will allow the calling application (TC) to provide a custom state object, which can be used in promo constraint queries:

```sql
custom.foo = 'bar'
```

This will be useful when we want to start writing constraints to match state in the TC application (e.g. donor status, etc.).

## Questions

What do you think of the API? Should it be called something other than `custom`?