### PR TITLE
Use a PRNG when picking promos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Bump standard to 13.1.0
 * Add scroll percent to context
 * Add custom state to context
+* Add `prng` function to utils
 
 ## 4.0.0 (2019-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add scroll percent to context
 * Add custom state to context
 * Add `prng` function to utils
+* Add `choose` function to utils
 
 ## 4.0.0 (2019-05-10)
 

--- a/src/placePromos.test.js
+++ b/src/placePromos.test.js
@@ -1,12 +1,7 @@
 import placePromos from './placePromos'
 
-// Mock the sample function to return the first `n` elements of a list. This is
-// so that we can predictably test the placements.
-jest.mock('fkit/dist/sample', () =>
-  jest.fn((n, values) => values.slice(0, n))
-)
-
 describe('placePromos', () => {
+  const seed = 123
   const a = { promoId: 1, groupId: null }
   const b = { promoId: 2, groupId: null }
   const c = { promoId: 3, groupId: 1 }
@@ -17,9 +12,9 @@ describe('placePromos', () => {
   const promos = [a, b, c, d, e, f, g]
 
   it('returns the promos that have satisfied constraints', () => {
-    expect(placePromos(promos, {})).toEqual([a, b, c])
-    expect(placePromos(promos, { x: 'foo' })).toEqual([a, b, c, e])
-    expect(placePromos(promos, { x: 'bar' })).toEqual([a, b, c, f])
-    expect(placePromos(promos, { x: 7 })).toEqual([a, b, c, g])
+    expect(placePromos(seed, promos, {})).toEqual([a, b, c])
+    expect(placePromos(seed, promos, { x: 'foo' })).toEqual([a, b, c, e])
+    expect(placePromos(seed, promos, { x: 'bar' })).toEqual([a, b, c, f])
+    expect(placePromos(seed, promos, { x: 7 })).toEqual([a, b, c, g])
   })
 })

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -29,13 +29,16 @@ const incrementVisits = update('visits', inc)
  * @returns {Promise} A promise that resolves to the promos.
  */
 function placementEngine (storage, promos, custom) {
+  // Generate a seed value for the PRNG.
+  const seed = Date.now()
+
   const user = getUser(storage)
 
   // The pipeline contains the steps in the placement engine algorithm.
   const pipeline = pipe(
     updateUser(storage, incrementVisits),
     createContext(custom),
-    placePromos(promos),
+    placePromos(seed, promos),
     resolvePromos(storage)
   )
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,3 +146,15 @@ export function prng (seed) {
     return ((t ^ t >>> 14) >>> 0) / 4294967296
   }
 }
+
+/**
+ * Chooses a random from an array, using a given pseudorandom number generator.
+ *
+ * @param {Function} rand The PRNG function.
+ * @param {Array} as An array.
+ * @return {Object} A random element from the array.
+ */
+export function choose (rand, as) {
+  const i = Math.floor(rand() * as.length)
+  return as[i]
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,3 +124,25 @@ export function scrollPercentY () {
   const b = document.body
   return (a.scrollTop || b.scrollTop) / ((a.scrollHeight || b.scrollHeight) - a.clientHeight)
 }
+
+/**
+ * Returns a pseudorandom number generator using the given seed value.
+ *
+ * The seed allows the generator to deterministically return the same sequence
+ * of pseudorandom numbers.
+ *
+ * This generator uses the mulberry32 algorithm, for more details see:
+ *
+ * https://gist.github.com/tommyettinger/46a874533244883189143505d203312c
+ *
+ * @param {Number} seed The seed value.
+ * @returns {Number} A random number.
+ */
+export function prng (seed) {
+  return () => {
+    var t = seed += 0x6D2B79F5
+    t = Math.imul(t ^ t >>> 15, t | 1)
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61)
+    return ((t ^ t >>> 14) >>> 0) / 4294967296
+  }
+}

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,6 +1,6 @@
 import id from 'fkit/dist/id'
 
-import { age, has, like, match, prng, scrollPercentX, scrollPercentY, timestamp, xeqBy } from './utils'
+import { age, choose, has, like, match, prng, scrollPercentX, scrollPercentY, timestamp, xeqBy } from './utils'
 
 describe('timestamp', () => {
   it('returns the ISO8601 timestamp', () => {
@@ -131,5 +131,13 @@ describe('prng', () => {
     expect(rand()).toBe(0.26642920868471265)
     expect(rand()).toBe(0.0003297457005828619)
     expect(rand()).toBe(0.2232720274478197)
+  })
+})
+
+describe('choose', () => {
+  it('returns a random element from the array', () => {
+    expect(choose(() => 0.1, [0, 1, 2])).toBe(0)
+    expect(choose(() => 0.5, [0, 1, 2])).toBe(1)
+    expect(choose(() => 0.9, [0, 1, 2])).toBe(2)
   })
 })

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,6 +1,6 @@
 import id from 'fkit/dist/id'
 
-import { age, has, like, match, scrollPercentX, scrollPercentY, timestamp, xeqBy } from './utils'
+import { age, has, like, match, prng, scrollPercentX, scrollPercentY, timestamp, xeqBy } from './utils'
 
 describe('timestamp', () => {
   it('returns the ISO8601 timestamp', () => {
@@ -122,5 +122,14 @@ describe('scrollPercentY', () => {
 
   it('returns the vertical scroll percentage', () => {
     expect(scrollPercentY()).toBe(0.5)
+  })
+})
+
+describe('prng', () => {
+  it('returns a pseudorandom number generator function', () => {
+    const rand = prng(0)
+    expect(rand()).toBe(0.26642920868471265)
+    expect(rand()).toBe(0.0003297457005828619)
+    expect(rand()).toBe(0.2232720274478197)
   })
 })


### PR DESCRIPTION
This PR has been extracted from my [reactive work](https://github.com/conversation/promos-client/pull/14).

I refactored the `placePromos` function to use a pseudorandom number generator (PRNG) when picking promos at random.

Being able to seed the PRNG is important, as it allows us to deterministically pick the same promos for the same seed value.

This is functionally equivalent to what we already have, so there is no change as far as TC is concerned.