### PR TITLE
Use default user state when local storage isn't present

### DIFF
--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -33,7 +33,7 @@ function createGroupSeeds (promos) {
  * - `onView`: The callback function that should be called if the user views a
  *   promo.
  *
- * @param {Storage} storage The storage object.
+ * @param {?Storage} storage The storage object.
  * @param {Array} promos The list of the candidate promos.
  * @param {Object} custom The custom state object.
  * @returns {Signal} A signal.

--- a/src/userState.js
+++ b/src/userState.js
@@ -1,17 +1,23 @@
 import curry from 'fkit/dist/curry'
 
+export const DEFAULT_USER_STATE = {
+  blocked: {},
+  impressions: {},
+  visits: 0
+}
+
 /**
  * Loads the user state.
  *
- * @param storage The storage object.
+ * @param {?Storage} storage The storage object.
  * @returns {Object} The user state.
  */
 export function getUser (storage) {
-  return JSON.parse(storage.getItem('user')) || {
-    blocked: {},
-    impressions: {},
-    visits: 0
+  if (!storage) {
+    return DEFAULT_USER_STATE
   }
+
+  return JSON.parse(storage.getItem('user')) || DEFAULT_USER_STATE
 }
 
 /**
@@ -20,11 +26,15 @@ export function getUser (storage) {
  * This function is curried for convenience, so that it can be either partially
  * or fully applied.
  *
- * @param {Storage} storage The storage object.
+ * @param {?Storage} storage The storage object.
  * @param {Object} user The user state.
  * @returns {Object} The user state.
  */
 export const setUser = curry((storage, user) => {
+  if (!storage) {
+    return DEFAULT_USER_STATE
+  }
+
   storage.setItem('user', JSON.stringify(user))
   return user
 })

--- a/src/userState.test.js
+++ b/src/userState.test.js
@@ -1,4 +1,4 @@
-import { getUser, setUser, updateUser } from './userState'
+import { getUser, setUser, updateUser, DEFAULT_USER_STATE } from './userState'
 
 const user = { visits: 1 }
 
@@ -10,10 +10,13 @@ describe('getUser', () => {
 
   it("returns the default user state if it's not in the store", () => {
     const storage = { getItem: jest.fn(() => null) }
-    expect(getUser(storage)).toEqual({
-      blocked: {},
-      impressions: {},
-      visits: 0
+    expect(getUser(storage)).toEqual(DEFAULT_USER_STATE)
+  })
+
+  describe("when storage isn't present", () => {
+    it('returns the default user state', () => {
+      const storage = null
+      expect(getUser(storage)).toEqual(DEFAULT_USER_STATE)
     })
   })
 })
@@ -24,6 +27,14 @@ describe('setUser', () => {
     const user = { visits: 1 }
     expect(setUser(storage, user)).toEqual({ visits: 1 })
     expect(storage.setItem).toHaveBeenCalledWith('user', '{"visits":1}')
+  })
+
+  describe("when storage isn't present", () => {
+    it('returns the default user state', () => {
+      const storage = null
+      const user = { visits: 1 }
+      expect(setUser(storage, user)).toEqual(DEFAULT_USER_STATE)
+    })
   })
 })
 


### PR DESCRIPTION
Some browsers might have their `localStorage` feature disabled, due to privacy and tracking reasons. We still want to render promos, even if that means serving less targeted promos.

**Manual testing steps**

- At the `master` branch
- Run `make node_modules dist`
- Run `npm link`
- Link it in a project running the `promos-client` (e.g.: `tc`)
    - Run `npm link @theconversation/promos-client` in the project folder
    - Keep in mind: you should disable `tc`'s Webpack Docker service and use the host `npm run webpack:dev` to be able to test this branch
        - Tip: remember to configure `WEBPACK_INLINE_DEV_SERVER: http://docker-host:8080/` for `tc`
- Disable cookies/local storage for your `localhost:3000`
    - Chrome: visit `chrome://settings/content/cookies` and add `localhost:3000` to the block list
    - Firefox: block `localhost:3000` in the settings. Instructions: https://support.mozilla.org/en-US/kb/storage
- Run the project and visit a page with a promo (e.g.: localhost:3000/article-2)
    - You should get an error saying that `storage.getItem` is undefined
- Checkout this branch
- Run `make node_modules dist`
- Visit a page with a promo (e.g.: localhost:3000/article-2)
    - Promos should be rendering just fine now
