### PR TITLE
Ensure horizontal and vertical scroll values are clamped between 0 and 1

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -116,9 +116,10 @@ export const xeqBy = f => (a, b) => {
  * @return {Number} The scroll amount in percent.
  */
 export function scrollPercentX () {
-  const a = document.documentElement
-  const b = document.body
-  return (a.scrollLeft || b.scrollLeft) / ((a.scrollWidth || b.scrollWidth) - a.clientWidth)
+  const { clientWidth, scrollWidth, scrollLeft } = document.documentElement || document.body
+  const scrollPercent = scrollLeft / (scrollWidth - clientWidth)
+
+  return clamp(scrollPercent, 0, 1)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,6 +12,15 @@ function escapeRegExp (s) {
 }
 
 /**
+ * Clamps the given value between min and max.
+ *
+ * @private
+ */
+function clamp (value, min, max) {
+  return Math.min(Math.max(min, value || 0), max)
+}
+
+/**
  * Returns the current timestamp.
  *
  * @returns {String} The ISO8601 date string.
@@ -121,13 +130,9 @@ export function scrollPercentX () {
  */
 export function scrollPercentY () {
   const { clientHeight, scrollHeight, scrollTop } = document.documentElement || document.body
-
-  if (!scrollTop) { return 0 }
-
   const scrollPercent = scrollTop / (scrollHeight - clientHeight)
-  const scrollPercentClamped = Math.min(Math.max(0, scrollPercent), 1)
 
-  return scrollPercentClamped
+  return clamp(scrollPercent, 0, 1)
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -122,7 +122,15 @@ export function scrollPercentX () {
 export function scrollPercentY () {
   const a = document.documentElement
   const b = document.body
-  return (a.scrollTop || b.scrollTop) / ((a.scrollHeight || b.scrollHeight) - a.clientHeight)
+
+  const maxScroll = (a.scrollHeight || b.scrollHeight) - a.clientHeight
+  const scrollTop = Math.min(maxScroll, Math.max(0, a.scrollTop || b.scrollTop))
+
+  if (maxScroll === 0) {
+    return 0
+  } else {
+    return scrollTop / maxScroll
+  }
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -120,17 +120,14 @@ export function scrollPercentX () {
  * @return {Number} The scroll amount in percent.
  */
 export function scrollPercentY () {
-  const a = document.documentElement
-  const b = document.body
+  const { clientHeight, scrollHeight, scrollTop } = document.documentElement || document.body
 
-  const maxScroll = (a.scrollHeight || b.scrollHeight) - a.clientHeight
-  const scrollTop = Math.min(maxScroll, Math.max(0, a.scrollTop || b.scrollTop))
+  if (!scrollTop) { return 0 }
 
-  if (maxScroll === 0) {
-    return 0
-  } else {
-    return scrollTop / maxScroll
-  }
+  const scrollPercent = scrollTop / (scrollHeight - clientHeight)
+  const scrollPercentClamped = Math.min(Math.max(0, scrollPercent), 1)
+
+  return scrollPercentClamped
 }
 
 /**

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -168,6 +168,18 @@ describe('scrollPercentY', () => {
       expect(scrollPercentY()).toBe(0)
     })
   })
+
+  describe('scrollTop is half way when scrollHeight equals clientHeight', () => {
+    it('returns 1', () => {
+      Object.defineProperties(document.documentElement, {
+        scrollTop: { value: 50, configurable: true },
+        scrollHeight: { value: 100, configurable: true },
+        clientHeight: { value: 100, configurable: true }
+      })
+
+      expect(scrollPercentY()).toBe(1.0)
+    })
+  })
 })
 
 describe('seedGenerator', () => {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -116,12 +116,48 @@ describe('scrollPercentX', () => {
 })
 
 describe('scrollPercentY', () => {
-  Object.defineProperty(document.documentElement, 'scrollTop', { value: 50 })
-  Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200 })
-  Object.defineProperty(document.documentElement, 'clientHeight', { value: 100 })
+  describe('with standard values', () => {
+    it('returns the vertical scroll percentage', () => {
+      Object.defineProperty(document.documentElement, 'scrollTop', { value: 50, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
 
-  it('returns the vertical scroll percentage', () => {
-    expect(scrollPercentY()).toBe(0.5)
+      expect(scrollPercentY()).toBe(0.5)
+    })
+  })
+
+  // Webkit/iOS can return negative scroll values for a scroll postition
+  // preceeding the scroll space.
+  describe('with values preceeding the scroll space', () => {
+    it('returns the vertical scroll percentage of 0', () => {
+      Object.defineProperty(document.documentElement, 'scrollTop', { value: -5, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+
+      expect(scrollPercentY()).toBe(0)
+    })
+  })
+
+  // Webkit/iOS can return scroll values > than the scroll space
+  // for a scroll postition proceeding the scroll space.
+  describe('with values preceeding the scroll space', () => {
+    it('returns the vertical scroll percentage of 1', () => {
+      Object.defineProperty(document.documentElement, 'scrollTop', { value: 105, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
+      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+
+      expect(scrollPercentY()).toBe(1)
+    })
+  })
+
+  describe('when scrollHeight equals the clientHeight', () => {
+    it('returns the vertical scroll percentage of 1', () => {
+      Object.defineProperty(document.documentElement, 'scrollTop', { value: 0, configurable: true })
+      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 100, configurable: true })
+      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+
+      expect(scrollPercentY()).toBe(0)
+    })
   })
 })
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -106,9 +106,11 @@ describe('xeqBy', () => {
 })
 
 describe('scrollPercentX', () => {
-  Object.defineProperty(document.documentElement, 'scrollLeft', { value: 50 })
-  Object.defineProperty(document.documentElement, 'scrollWidth', { value: 200 })
-  Object.defineProperty(document.documentElement, 'clientWidth', { value: 100 })
+  Object.defineProperties(document.documentElement, {
+    scrollLeft: { value: 50 },
+    scrollWidth: { value: 200 },
+    clientWidth: { value: 100 }
+  })
 
   it('returns the horizontal scroll percentage', () => {
     expect(scrollPercentX()).toBe(0.5)
@@ -116,45 +118,52 @@ describe('scrollPercentX', () => {
 })
 
 describe('scrollPercentY', () => {
-  describe('with standard values', () => {
-    it('returns the vertical scroll percentage', () => {
-      Object.defineProperty(document.documentElement, 'scrollTop', { value: 50, configurable: true })
-      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
-      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+  describe('scrollTop is half way through the document', () => {
+    it('returns 0.5', () => {
+      Object.defineProperties(document.documentElement, {
+        scrollTop: { value: 50, configurable: true },
+        scrollHeight: { value: 200, configurable: true },
+        clientHeight: { value: 100, configurable: true }
+      })
 
       expect(scrollPercentY()).toBe(0.5)
     })
   })
 
-  // Webkit/iOS can return negative scroll values for a scroll postition
-  // preceeding the scroll space.
-  describe('with values preceeding the scroll space', () => {
-    it('returns the vertical scroll percentage of 0', () => {
-      Object.defineProperty(document.documentElement, 'scrollTop', { value: -5, configurable: true })
-      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
-      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+  // Webkit/iOS can return scroll values less than zero
+  describe('scrollTop has a negative value', () => {
+    it('clamps the return value to 0', () => {
+      Object.defineProperties(document.documentElement, {
+        scrollTop: { value: -5, configurable: true },
+        scrollHeight: { value: 200, configurable: true },
+        clientHeight: { value: 100, configurable: true }
+      })
 
       expect(scrollPercentY()).toBe(0)
     })
   })
 
-  // Webkit/iOS can return scroll values > than the scroll space
-  // for a scroll postition proceeding the scroll space.
-  describe('with values preceeding the scroll space', () => {
-    it('returns the vertical scroll percentage of 1', () => {
-      Object.defineProperty(document.documentElement, 'scrollTop', { value: 105, configurable: true })
-      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 200, configurable: true })
-      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+  // Webkit/iOS can return scroll values greater than the
+  // total height of the document
+  describe('scrollTop exceeds the height of the document', () => {
+    it('clamps the return value to 1', () => {
+      Object.defineProperties(document.documentElement, {
+        scrollTop: { value: 105, configurable: true },
+        scrollHeight: { value: 200, configurable: true },
+        clientHeight: { value: 100, configurable: true }
+      })
 
       expect(scrollPercentY()).toBe(1)
     })
   })
 
-  describe('when scrollHeight equals the clientHeight', () => {
-    it('returns the vertical scroll percentage of 1', () => {
-      Object.defineProperty(document.documentElement, 'scrollTop', { value: 0, configurable: true })
-      Object.defineProperty(document.documentElement, 'scrollHeight', { value: 100, configurable: true })
-      Object.defineProperty(document.documentElement, 'clientHeight', { value: 100, configurable: true })
+  describe('scrollTop is zero', () => {
+    it('returns 0', () => {
+      Object.defineProperties(document.documentElement, {
+        scrollTop: { value: 0, configurable: true },
+        scrollHeight: { value: 200, configurable: true },
+        clientHeight: { value: 100, configurable: true }
+      })
 
       expect(scrollPercentY()).toBe(0)
     })


### PR DESCRIPTION
Currently on iOS, "overscrolling" the edge of the screen results in values of `Infinity` or `NaN` due to dividing by zero or zero being divided by some other value.

By clamping the values between 0 and 1 we avoid this problem.