### PR TITLE
Expose the CQL parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Expose the CQL Parser
+
 ## 5.2.0 (2020-11-09)
 
 * Prevent iOS overscrolling (https://github.com/conversation/promos-client/pull/24)

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { default as placementEngine } from './placementEngine'
+export { default as CQLParser } from './parser'


### PR DESCRIPTION
This allow importing the parser, allowing evaluating constraint expressions outside the placement engine.