### PR TITLE
Target ES modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ parser:
 	@npx jison src/parser.jison -o src/parser.js -m commonjs
 
 dist:
-	@npx babel --copy-files --out-dir dist src
+	@mkdir -p dist/cjs dist/esm
+	@npx babel --copy-files --out-dir dist/cjs src
+	@cp -r src/* dist/esm
 
 test:
 	@npx jest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,14 @@
     "theconversation",
     "promo"
   ],
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This PR updates the package config to include ESM files, as well as the common JS files built by Babel.

We can include both types of packages using [package exports](https://webpack.js.org/guides/package-exports/) in the `package.json` file. This allows us to perform tree shaking properly, as TC will include the ESM version of the package, while still allowing the package to be required from a common JS file.

More info: https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html

## How to test

If you want to test this works locally:

* Build the promos-client package `make dist`
* Make the package linkable `npm ln`
* Link to the package in TC: `npm ln @theconversation/promos-client`
* Build the bundle: `npm run webpack:prod`