### PR TITLE
Fix esm build for use with Webpack 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix esm build so that it works with webpack 5
+
 ## 5.5.0 (2021-09-01)
 
 * Replace Replace Bulb with RxJS (https://github.com/conversation/promos-client/pull/34)

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ parser:
 
 dist:
 	@mkdir -p dist/cjs dist/esm
-	@npx babel --copy-files --out-dir dist/cjs src
-	@cp -r src/* dist/esm
+	@npx babel --delete-dir-on-start --copy-files --out-dir dist/cjs src
+	@npx babel --delete-dir-on-start --copy-files --env-name esm --out-dir dist/esm src
 
 test:
 	@npx jest

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,12 @@
 module.exports = api => {
-  const env = api.cache(() => process.env.NODE_ENV)
-  const ignore = env === 'test' ? [] : [/test\.jsx?$/]
+  const nodeEnv = api.cache(() => process.env.NODE_ENV)
+  const ignore = nodeEnv === 'test' ? [] : [/test\.jsx?$/]
   const presets = ['@babel/preset-env']
+  const env = {
+    esm: {
+      presets: [['@babel/preset-env', { modules: false }]]
+    }
+  }
 
-  return { ignore, presets }
+  return { ignore, presets, env }
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,6 @@
     "test": "jest",
     "lint": "standard"
   },
-  "exports": {
-    ".": {
-      "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js"
-    }
-  },
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "type": "git",
     "url": "git+ssh://git@github.com/conversation/promos-client.git"
   },
+  "browser": {
+    "fs": false,
+    "path": false
+  },
   "dependencies": {
     "fkit": "^3.4.0",
     "rxjs": "^7.3.0",


### PR DESCRIPTION
Mostly just bringing it into line with our other packages which compile and work fine with Webpack 5, the only notable addition is:
```js
  "browser": {
    "fs": false,
    "path": false
  },
```

I didn't really have the time to investigate this part properly, but on the surface it looks like the autogenerated `src/parser.js` code is just inappropriate for browsers, with that extra config it'll basically just tell webpack to ignore `require` statements for `fs` and `path`, which probably shouldn't be there in the first place. But it at least works.

Will release a new version separately, probably a major version bump because it changes the distributables a fair bit.