### PR TITLE
Fix package publish GitHub workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,7 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ parser:
 	@npx jison src/parser.jison -o src/parser.js -m commonjs
 
 dist:
-	@mkdir -p dist/cjs dist/esm
-	@npx babel --delete-dir-on-start --copy-files --out-dir dist/cjs src
-	@npx babel --delete-dir-on-start --copy-files --env-name esm --out-dir dist/esm src
+	@npm run build
 
 test:
 	@npx jest

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "module": "dist/esm/index.js",
   "scripts": {
     "test": "jest",
-    "lint": "standard"
+    "lint": "standard",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "babel --delete-dir-on-start --copy-files --out-dir dist/cjs src",
+    "build:esm": "babel --delete-dir-on-start --copy-files --env-name esm --out-dir dist/esm src"
   },
   "files": [
     "dist"


### PR DESCRIPTION
We were missing files in the 6.0.0 release and didn't notice, because the `package` workflow wasn't actually working.

Fixed now, you can see that the 6.0.1-rc3 release contains files:
https://github.com/conversation/promos-client/runs/5178452834

```
./promos-client$ cat package.json | grep version
  "version": "6.0.1-rc3",
./promos-client$ tree dist | wc -l
45
```