### PR TITLE
Export DEFAULT_USER_STATE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as placementEngine } from './placementEngine'
 export { default as CQLParser } from './parser'
+export { DEFAULT_USER_STATE } from './userState'

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,15 @@
+import { placementEngine, CQLParser, DEFAULT_USER_STATE } from '.'
+
+describe('index', () => {
+  it('exports placementEngine', () => {
+    expect(typeof placementEngine).toEqual('function')
+  })
+
+  it('exports CQLParser', () => {
+    expect(typeof CQLParser.parse).toEqual('function')
+  })
+
+  it('exports DEFAULT_USER_STATE', () => {
+    expect(DEFAULT_USER_STATE.visits).toEqual(0)
+  })
+})


### PR DESCRIPTION
In TC, we're [looking at bringing donations state into promos](https://github.com/conversation/tc/pull/12488), which will mean manipulating the user state in local storage. That will mean that TC will need the ability to initialise the user state, and we'd [like to be able to](https://github.com/conversation/tc/pull/12488#discussion_r872348778) bring this in from promos-client. Export it here (and add some quick specs on our exports for good measure).
