### PR TITLE
Declare TS module to infer the `any` type to promos client exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 6.2.0 (2022-05-31)
+
+* Add TypeScript module declaration (`types.d.ts`)
+
 ## 6.1.0 (2022-05-18)
 
 * Export the `DEFAULT_USER_STATE` constant (https://github.com/conversation/promos-client/pull/44)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@theconversation/promos-client",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@theconversation/promos-client",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "MIT",
       "dependencies": {
         "fkit": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theconversation/promos-client",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Provides various functions for querying The Conversation's promos API",
   "author": "The Conversation <platform@theconversation.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "typings": "./types.d.ts",
   "scripts": {
     "test": "jest",
     "lint": "standard",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,4 @@
+// `@theconversation/promos-client` is a JS project without typescript definitions.
+// Let's declare its exports with the "any" type, so TS can explicitly infer types for it, avoiding
+// TS compiler error code 7016.
+declare module "@theconversation/promos-client"


### PR DESCRIPTION
We are not declaring any types for the `promos-client` at the moment, but declaring an empty module will avoid TypeScript compilation error code 7016, which assumes we are implicitly declaring that exports have the "any" type.

We are now explicitly declaring it has the "any" type.

## Manual testing steps

* At the `main` branch
* Link this project to a project that is using the `@theconversation/promos-client` and TypeScript
  * Example:

```js
// At `tc/frontend/package.json` dependencies, you can reference the relative/absolute path to your files

{
  "dependencies": {
    "@theconversation/promos-client": "file:../../promos-client",
  }
}
```

_You could also use `npm link`, whatever technique you prefer._

* Create the `promos-client` distribution version (e.g.: `make dist`)
* Import the placements engine and try to compile the project
  * Example: anywhere in your project, import the placement engine

```ts
import { placementEngine } from "@theconversation/promos-client"
```

* Now, compile your project
  * For `tc/frontend` run `npm run build`
* You should see an error, like this:

![image](https://user-images.githubusercontent.com/1538066/171261792-2b261808-75a2-4d6d-84c1-e6905ba99dd3.png)

Let's fix it!

* Checkout this branch
* Run `make dist`
* Compile your project again
  * The error is now gone :rocket: 
