### PR TITLE
Handle external changes to user

### DIFF
--- a/src/stateMachine.js
+++ b/src/stateMachine.js
@@ -42,6 +42,8 @@ export default function stateMachine (storage, promos, custom = {}) {
       user = blockPromo(ts, event.promo)(user)
     } else if (event.type === 'view') {
       user = trackImpression(ts, event.promo)(user)
+    } else if (event.type === 'donationsLoaded') {
+      user = { ...user, donations: event.donations }
     }
 
     let placedPromos = null

--- a/src/stateMachine.test.js
+++ b/src/stateMachine.test.js
@@ -178,4 +178,23 @@ describe('stateMachine', () => {
       })
     })
   })
+
+  describe('with a donationsLoaded event', () => {
+    const event = {
+      type: 'donationsLoaded',
+      donations: { custom: 'field' }
+    }
+
+    it('updates the custom fields', () => {
+      expect(state).not.toHaveProperty('user.donations')
+      state = stateMachine(storage, promos)(state, event)
+      expect(state).toHaveProperty('user.donations.custom', 'field')
+    })
+
+    it('makes no change to other fields', () => {
+      expect(state).toHaveProperty('user.visits', 1)
+      state = stateMachine(storage, promos)(state, event)
+      expect(state).toHaveProperty('user.visits', 1)
+    })
+  })
 })


### PR DESCRIPTION
We now add user donation details in the user state (https://github.com/conversation/tc/pull/12488). However, the promos state machine is not notified of this asynchronous change to the user state, and so will stomp those changes if there is a subsequent update. Add an event handler which will allow TC to notify the promos client of any changes.
