### PR TITLE
Include `types.d.ts` file when publishing to npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Include `types.d.ts` in module distribution (adding its reference to `package.json` `files` field)
+
 ## 6.3.0 (2022-06-01)
 
 * Add `donationsLoaded` event handler (https://github.com/conversation/promos-client/pull/46)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:esm": "babel --delete-dir-on-start --copy-files --env-name esm --out-dir dist/esm src"
   },
   "files": [
-    "dist"
+    "dist",
+    "types.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Related to https://github.com/conversation/promos-client/pull/45

While https://github.com/conversation/promos-client/pull/45 created the `types.d.ts` file, the pull request didn't include it in the `package.json`.

This PR fixes this, making the file available after module is downloaded from `npm`.