### PR TITLE
Pass promo types to the promos engine context

### DIFF
--- a/src/placePromos.js
+++ b/src/placePromos.js
@@ -13,7 +13,7 @@ import runQuery from './runQuery'
 import { choose, prng, xeqBy } from './utils'
 
 // The properties to copy from a promo into a context.
-const PROMO_PROPERTIES = ['creativeId', 'promoId', 'slotId', 'groupId', 'campaignId']
+const PROMO_PROPERTIES = ['creativeId', 'promoId', 'slotId', 'groupId', 'campaignId', 'type']
 
 /**
  * Returns `true` if the promo's constraints are satisfied in the given context,

--- a/src/placePromos.test.js
+++ b/src/placePromos.test.js
@@ -9,12 +9,14 @@ describe('placePromos', () => {
   const e = { promoId: 5, groupId: 2, constraints: 'x = "foo"' }
   const f = { promoId: 6, groupId: 2, constraints: 'x = "bar"' }
   const g = { promoId: 7, groupId: 3, constraints: 'x = promoId' }
-  const promos = [a, b, c, d, e, f, g]
+  const h = { promoId: 8, groupId: 4, type: 'DesktopBanner', constraints: 'type = "DesktopBanner"' }
+  const i = { promoId: 10, groupId: 4, type: 'MobileBanner', constraints: 'type = "DesktopBanner"' }
+  const promos = [a, b, c, d, e, f, g, h, i]
 
   it('returns the promos that have satisfied constraints', () => {
-    expect(placePromos(seed, promos, {})).toEqual([a, b, c])
-    expect(placePromos(seed, promos, { x: 'foo' })).toEqual([a, b, c, e])
-    expect(placePromos(seed, promos, { x: 'bar' })).toEqual([a, b, c, f])
-    expect(placePromos(seed, promos, { x: 7 })).toEqual([a, b, c, g])
+    expect(placePromos(seed, promos, {})).toEqual([a, b, c, h])
+    expect(placePromos(seed, promos, { x: 'foo' })).toEqual([a, b, c, e, h])
+    expect(placePromos(seed, promos, { x: 'bar' })).toEqual([a, b, c, f, h])
+    expect(placePromos(seed, promos, { x: 7 })).toEqual([a, b, c, g, h])
   })
 })


### PR DESCRIPTION
* Related to consent management work: https://trello.com/c/ONAKCyni/9818-consent-management

This PR adds a new promo property to the promos engine context: the `type`.

When placing promos, the engine will now copy the `promo.type` property to its context, allowing us to write CQL queries with it, such as:

```
window.location.search =~ "promos=on" AND type NOT IN ["DonationDialog", "DesktopBanner"]
```

Such query allows us to only show promos when we have the `?promos=on` query string, and campaign or promo will never allow promo types of the `DonationDialog` and `DesktopBanner`!

This gives us the ability to hide certain creative types at will, meaning that we can hide certain promos if users didn't give consent.