### PR TITLE
Allow the placement engine refresh event to pass a custom context

### DIFF
--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -61,7 +61,7 @@ function placementEngine (storage, promos, custom = {}) {
   const onRefresh = promo => subject.next({ type: 'refresh', promo })
 
   // Create the initial state object.
-  const initialState = { seeds, user }
+  const initialState = { seeds, user, custom }
 
   // The stateful signal emits the current placement engine state whenever an event is emitted on
   // the subject.
@@ -70,7 +70,7 @@ function placementEngine (storage, promos, custom = {}) {
       startWith({ type: 'visit' }),
 
       // Run the state machine function over the events emitted on the bus.
-      scan(stateMachine(storage, promos, custom), initialState),
+      scan(stateMachine(storage, promos), initialState),
 
       // Don't emit the state if it doesn't contain any promos.
       filter(({ promos }) => promos),

--- a/src/placementEngine.js
+++ b/src/placementEngine.js
@@ -58,7 +58,7 @@ function placementEngine (storage, promos, custom = {}) {
   const onView = promo => subject.next({ type: 'view', promo })
 
   // A function that emits a `refresh` event on the subject.
-  const onRefresh = promo => subject.next({ type: 'refresh', promo })
+  const onRefresh = () => subject.next({ type: 'refresh' })
 
   // Create the initial state object.
   const initialState = { seeds, user, custom }

--- a/src/placementEngine.test.js
+++ b/src/placementEngine.test.js
@@ -47,9 +47,9 @@ describe('placementEngine', () => {
     placementEngine(storage, promos)
       .subscribe(state => {
         expect(state.promos).toEqual(promos)
-        expect(stateMachine).toHaveBeenLastCalledWith(storage, promos, {})
+        expect(stateMachine).toHaveBeenLastCalledWith(storage, promos)
         expect(innerMock).toHaveBeenLastCalledWith(
-          { seeds, user },
+          { seeds, user, custom: {} },
           { type: 'visit' },
           expect.anything()
         )

--- a/src/stateMachine.js
+++ b/src/stateMachine.js
@@ -26,12 +26,12 @@ const trackEngagement = incrementCounters('engagements')
  *
  * @param {Storage} storage The storage object.
  * @param {Array} promos The list of promos.
- * @param {Object} custom The custom state object.
  * @returns A new state.
  */
-export default function stateMachine (storage, promos, custom = {}) {
-  return ({ seeds, user }, event) => {
+export default function stateMachine (storage, promos) {
+  return ({ seeds, user, custom }, event) => {
     const ts = timestamp()
+    const customState = event.custom || custom
 
     // Update the user state based on the event type.
     if (event.type === 'visit') {
@@ -50,13 +50,13 @@ export default function stateMachine (storage, promos, custom = {}) {
 
     // Place and emit the promos.
     if (event.type === 'visit' || event.type === 'refresh') {
-      const context = createContext(user, custom)
+      const context = createContext(user, customState)
       placedPromos = placePromos(seeds, promos, context)
     }
 
     // Store the user state as a side effect.
     setUser(storage, user)
 
-    return { seeds, user, promos: placedPromos }
+    return { seeds, user, custom: customState, promos: placedPromos }
   }
 }

--- a/src/stateMachine.test.js
+++ b/src/stateMachine.test.js
@@ -1,6 +1,7 @@
 import mockStorage from './mockStorage'
 import stateMachine from './stateMachine'
 import { setUser } from './userState'
+import createContext from './createContext'
 
 // Mock the createContext function.
 jest.mock('./createContext', () => jest.fn((user) => ({ user })))
@@ -68,6 +69,26 @@ describe('stateMachine', () => {
       expect(state).toHaveProperty('user.visits', 1)
       state = stateMachine(storage, promos)(state, event)
       expect(state).toHaveProperty('user.visits', 2)
+    })
+  })
+
+  describe('with a refresh event', () => {
+    it('returns the custom state object', () => {
+      const event = { type: 'refresh' }
+
+      state = { ...state, custom: { context: 'custom context' } }
+      state = stateMachine(storage, promos)(state, event)
+
+      expect(state.custom).toEqual({ context: 'custom context' })
+    })
+
+    it('replaces the custom state object with the context of the event', () => {
+      const event = { type: 'refresh', custom: { event: 'custom context from the event' } }
+
+      state = { ...state, custom: { context: 'custom context' } }
+      stateMachine(storage, promos)(state, event)
+
+      expect(createContext).toHaveBeenLastCalledWith(state.user, { event: 'custom context from the event' })
     })
   })
 


### PR DESCRIPTION
When invoking the promos engine refresh event, we want to be able to update its custom context object, allowing us to update the custom context of the placement engine after it has been initialized.

This gives us the ability to update the placement engine context after it has been initialized.

E.g.:

```
const signal = placementEngine(storage, promos, context)

// We are now going going to add more information to the placement
// engine context:
const consent = true

signal.next({ type: "refresh", custom: { ...context, consent } })
```