### PR TITLE
Limit one promo per slot

### DIFF
--- a/src/placePromos.js
+++ b/src/placePromos.js
@@ -66,6 +66,19 @@ const chunkPromosByGroupId = chunkBy(xeqBy(get('groupId')))
 const chooseOnePromoFromEachGroup = seeds => map(group => choose(prng(seeds[group[0].groupId]), group))
 
 /**
+ * Chooses the first promo for each slot
+ *
+ * Only one promo from each slot may be placed at the same time. We're leveraging the randomness of groups to avoid piping additional seeds
+ * to this function to make it random.
+ *
+ * @private
+ */
+function chooseFirstPromoPerSlot (promos) {
+  const slotsUsed = new Set()
+  return promos.filter(({ slotId }) => slotId === undefined || (!slotsUsed.has(slotId) && slotsUsed.add(slotId)))
+}
+
+/**
  * Places the promos based on the following rules:
  *
  *   - Promos with satisfied constraints will be placed, otherwise they are skipped.
@@ -86,7 +99,8 @@ function placePromos (seeds, promos, context) {
     filterPromos(context),
     sortPromosByGroupId,
     chunkPromosByGroupId,
-    chooseOnePromoFromEachGroup(seeds)
+    chooseOnePromoFromEachGroup(seeds),
+    chooseFirstPromoPerSlot
   ])
 
   return pipeline(promos)

--- a/src/placePromos.test.js
+++ b/src/placePromos.test.js
@@ -2,8 +2,9 @@ import placePromos from './placePromos'
 
 describe('placePromos', () => {
   const seed = 123
-  const a = { promoId: 1, groupId: null }
-  const b = { promoId: 2, groupId: null }
+  const a = { promoId: 1, groupId: null, slotId: 1 }
+  const b = { promoId: 2, groupId: null, slotId: 2 }
+  const bb = { promoId: 22, groupId: null, slotId: 2 }
   const c = { promoId: 3, groupId: 1 }
   const d = { promoId: 4, groupId: 1 }
   const e = { promoId: 5, groupId: 2, constraints: 'x = "foo"' }
@@ -11,7 +12,7 @@ describe('placePromos', () => {
   const g = { promoId: 7, groupId: 3, constraints: 'x = promoId' }
   const h = { promoId: 8, groupId: 4, type: 'DesktopBanner', constraints: 'type = "DesktopBanner"' }
   const i = { promoId: 10, groupId: 4, type: 'MobileBanner', constraints: 'type = "DesktopBanner"' }
-  const promos = [a, b, c, d, e, f, g, h, i]
+  const promos = [a, b, bb, c, d, e, f, g, h, i]
 
   it('returns the promos that have satisfied constraints', () => {
     expect(placePromos(seed, promos, {})).toEqual([a, b, c, h])


### PR DESCRIPTION
Implement the logic from https://github.com/conversation/tc/pull/16834 here.
We ran into an issue where two promos in the same slot where being triggered at the same time.  This is an attempt to prevent this.